### PR TITLE
Limit total memory to 2G

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,8 @@ const config = {
     "--no-sandbox",
     "--disable-setuid-sandbox",
     "--disable-gpu",
-    '--js-flags="--max_old_space_size=500"'
+    '--js-flags="--max_old_space_size=200"',
+    "--renderer-process-limit 10"
   ],
   executablePath: process.env.CHROME_BIN
 };


### PR DESCRIPTION
Limit total memory to 2G.

`max_old_space_size` only applies to 1 process, so we need to limit the total number of procs