### PR TITLE
Add a livenessProbe to the POD

### DIFF
--- a/kubernetes/manifests/pod.yml.j2
+++ b/kubernetes/manifests/pod.yml.j2
@@ -57,6 +57,14 @@ spec:
             successThreshold: 1
             timeoutSeconds: 2
             failureThreshold: 5
+          livenessProbe:
+            httpGet:
+              path: "/url=http%3A%2F%2Fwww.google.com&width=1&height=1"
+              port: {{ service_port }}
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 3
+            failureThreshold: 5
           # Give K8S enough time to remove this Pod before actually sending the SIGTERM
           # More info: https://github.com/kubernetes/kubernetes/issues/43576
           lifecycle:


### PR DESCRIPTION
The idea is that if for 5 consecutive times (tried every 2 seconds) the HTTP request fails, the pod is terminated. We have seen with production traffic that when Chrome dies all the request fail with a 500 error.

We keep the readinessProbe as TCP check because it's good enough, to be said. nodejs inits Puppeteer and this one starts Chrome and start listening in the socket. At that point, service is ready.

Please note that the problem we are facing is that Chrome dies/terminates and Puppeteer does not manage that properly, so POD should be terminated because it's in a failing state.